### PR TITLE
Update based on input from Danny

### DIFF
--- a/src/main/java/com/scaleunlimited/CountRecordsRead.java
+++ b/src/main/java/com/scaleunlimited/CountRecordsRead.java
@@ -1,0 +1,46 @@
+package com.scaleunlimited;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.flink.api.common.accumulators.IntCounter;
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.configuration.Configuration;
+
+@SuppressWarnings("serial") 
+public class CountRecordsRead extends RichFilterFunction<EnrichedRecord> {
+    
+    // During testing, to get actual count
+    private static final AtomicInteger READ_COUNT = new AtomicInteger();
+    
+    private final String counterName;
+    
+    private transient IntCounter recordCounter;
+    
+    public CountRecordsRead(String counterName) {
+        this.counterName = counterName;
+    }
+    
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        
+        recordCounter = getRuntimeContext().getIntCounter(counterName);
+    }
+    
+    @Override
+    public boolean filter(EnrichedRecord value) throws Exception {
+        recordCounter.add(1);
+        
+        READ_COUNT.incrementAndGet();
+        
+        return true;
+    }
+    
+    public static void resetCount() {
+        READ_COUNT.set(0);
+    }
+    
+    public static int getCount() {
+        return READ_COUNT.get();
+    }
+}

--- a/src/main/java/com/scaleunlimited/CountRecordsWritten.java
+++ b/src/main/java/com/scaleunlimited/CountRecordsWritten.java
@@ -1,17 +1,22 @@
 package com.scaleunlimited;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.flink.api.common.accumulators.IntCounter;
 import org.apache.flink.api.common.functions.RichFilterFunction;
 import org.apache.flink.configuration.Configuration;
 
 @SuppressWarnings("serial") 
-public class CountRecords extends RichFilterFunction<EnrichedRecord> {
+public class CountRecordsWritten extends RichFilterFunction<EnrichedRecord> {
+    
+    // During testing, to get actual count
+    private static final AtomicInteger WRITE_COUNT = new AtomicInteger();
     
     private final String counterName;
     
     private transient IntCounter recordCounter;
     
-    public CountRecords(String counterName) {
+    public CountRecordsWritten(String counterName) {
         this.counterName = counterName;
     }
     
@@ -26,6 +31,16 @@ public class CountRecords extends RichFilterFunction<EnrichedRecord> {
     public boolean filter(EnrichedRecord value) throws Exception {
         recordCounter.add(1);
         
+        WRITE_COUNT.incrementAndGet();
+        
         return true;
+    }
+    
+    public static void resetCount() {
+        WRITE_COUNT.set(0);
+    }
+    
+    public static int getCount() {
+        return WRITE_COUNT.get();
     }
 }

--- a/src/main/java/com/scaleunlimited/ExampleReaderWorkflow.java
+++ b/src/main/java/com/scaleunlimited/ExampleReaderWorkflow.java
@@ -7,7 +7,6 @@ public class ExampleReaderWorkflow {
 
     public static final String RECORD_COUNTER_NAME = "enriched-record-read-counter";
     
-
     private DataStream<EnrichedRecord> input;
     
     public ExampleReaderWorkflow setInput(DataStream<EnrichedRecord> input) {
@@ -16,7 +15,9 @@ public class ExampleReaderWorkflow {
     }
     
     public void build() {
-        input.filter(new CountRecords(RECORD_COUNTER_NAME))
-        .addSink(new DiscardingSink<>());
+        input.filter(new CountRecordsRead(RECORD_COUNTER_NAME))
+        .name("Count read record")
+        .addSink(new DiscardingSink<>())
+        .name("End of reader workflow");
     }
 }

--- a/src/main/java/com/scaleunlimited/ExampleWriterWorkflow.java
+++ b/src/main/java/com/scaleunlimited/ExampleWriterWorkflow.java
@@ -6,8 +6,8 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 
 public class ExampleWriterWorkflow {
 
-    public static final String RECORD_COUNTER_NAME = "enriched-record-write-counter";
-    
+    public static final String RECORD_COUNTER_NAME = "enriched-record-written-counter";
+
     private DataStream<ExampleRecord> input;
     private DataStream<EnrichmentRecord> enrichments;
     private Consumer<DataStream<EnrichedRecord>> output;
@@ -31,7 +31,9 @@ public class ExampleWriterWorkflow {
         DataStream<EnrichedRecord> enriched = input
                 .connect(enrichments.broadcast(AddEnrichments.BROADCAST_STATE))
                 .process(new AddEnrichments())
-                .filter(new CountRecords(RECORD_COUNTER_NAME));
+                .name("Add enrichments")
+                .filter(new CountRecordsWritten(RECORD_COUNTER_NAME))
+                .name("Count written records");
         
         output.accept(enriched);
                 

--- a/src/main/java/com/scaleunlimited/HudiUtils.java
+++ b/src/main/java/com/scaleunlimited/HudiUtils.java
@@ -2,19 +2,32 @@ package com.scaleunlimited;
 
 import java.util.function.Consumer;
 
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.formats.avro.typeutils.AvroSchemaConverter;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.configuration.FlinkOptions;
+import org.apache.hudi.configuration.OptionsInference;
 import org.apache.hudi.keygen.CustomAvroKeyGenerator;
 import org.apache.hudi.keygen.constant.KeyGeneratorType;
 import org.apache.hudi.sink.utils.Pipelines;
+import org.apache.hudi.source.StreamReadMonitoringFunction;
+import org.apache.hudi.source.StreamReadOperator;
+import org.apache.hudi.table.format.FilePathUtils;
+import org.apache.hudi.table.format.mor.MergeOnReadInputFormat;
+import org.apache.hudi.table.format.mor.MergeOnReadInputSplit;
 
 public class HudiUtils {
 
@@ -37,34 +50,50 @@ public class HudiUtils {
 
         return (stream) -> {
             DataStream<RowData> rowData = stream
-                    .map(new ConvertToRowData(rowType));
+                    .map(new ConvertToRowData(rowType))
+                    .name("Convert Enriched to RowData");
 
-            Pipelines.bulkInsert(config, rowType, rowData);
+            final boolean bounded = false;
+            Pipelines.append(config, rowType, rowData, bounded);
         };
     }
 
-    public static void setHudiWriteConfig(Configuration config, String tablePath, int writeParallelism) {
+    public static void setHudiConfig(Configuration config, String tablePath) {
         config.setString(FlinkOptions.PATH, tablePath);
-        config.set(FlinkOptions.WRITE_TASKS, writeParallelism);
         config.set(FlinkOptions.TABLE_NAME, HudiConstants.TABLE_NAME);
-        config.set(FlinkOptions.TABLE_TYPE, HoodieTableType.MERGE_ON_READ.name());
-        config.set(FlinkOptions.OPERATION, WriteOperationType.BULK_INSERT.value());
+        config.set(FlinkOptions.TABLE_TYPE, HoodieTableType.COPY_ON_WRITE.name());
         config.setString(FlinkOptions.SOURCE_AVRO_SCHEMA, EnrichedRecord.getClassSchema().toString());
-
-        config.setBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, false);
-        config.setBoolean(FlinkOptions.WRITE_BULK_INSERT_SHUFFLE_INPUT, false);
 
         config.setString(FlinkOptions.KEYGEN_TYPE, KeyGeneratorType.CUSTOM.name());
         config.setString(FlinkOptions.KEYGEN_CLASS_NAME, CustomAvroKeyGenerator.class.getName());
         
         config.setString(FlinkOptions.RECORD_KEY_FIELD, HudiConstants.RECORD_KEY_FIELD);
         config.setString(FlinkOptions.PARTITION_PATH_FIELD, HudiConstants.PARTITION_PATH_FIELD);
+    }
+
+    public static void setHudiWriteConfig(Configuration config, String tablePath, int writeParallelism) {
+        setHudiConfig(config, tablePath);
+        
+        config.set(FlinkOptions.WRITE_TASKS, writeParallelism);
+        config.set(FlinkOptions.OPERATION, WriteOperationType.INSERT.value());
+
+        config.setBoolean(FlinkOptions.WRITE_BULK_INSERT_SORT_INPUT, false);
+        config.setBoolean(FlinkOptions.WRITE_BULK_INSERT_SHUFFLE_INPUT, false);
 
         // Set all of these to 1MB, so we can run easily in our MiniCluster
         config.setDouble(FlinkOptions.WRITE_TASK_MAX_SIZE, 1);
         config.setInteger(FlinkOptions.WRITE_PARQUET_PAGE_SIZE, 1);
         config.setInteger(FlinkOptions.WRITE_PARQUET_BLOCK_SIZE, 1);
         config.setInteger(FlinkOptions.WRITE_PARQUET_MAX_FILE_SIZE, 1);
+    }
+
+    public static void setHudiReadConfig(Configuration config, String tablePath, int readParallelism) {
+        setHudiConfig(config, tablePath);
+        
+        config.set(FlinkOptions.QUERY_TYPE, FlinkOptions.QUERY_TYPE_SNAPSHOT);
+        config.setBoolean(FlinkOptions.READ_AS_STREAMING, true);
+        config.set(FlinkOptions.READ_TASKS, readParallelism);
+        config.set(FlinkOptions.READ_START_COMMIT, FlinkOptions.START_COMMIT_EARLIEST);
     }
 
 }


### PR DESCRIPTION
Based on input from Danny Chan:

- Switch to COW (Copy-on-write) table, was MOR
- For writing, switch to `WriteOperationType.INSERT`, was `BULK_INSERT`.
- For reading, switch to `FlinkOptions.QUERY_TYPE_SNAPSHOT`, was `QUERY_TYPE_INCREMENTAL`.
- For reading, don't use `HoodieTableSource.getInputFormat()` (should be flagged as @VisibleForTesting), instead use `HoodieTableSource.getScanRuntimeProvider()`, which sets up the `StreamReadMonitoringFunction` that's needed to do incremental reads.
- Update tests to work even though the read workflow will (as we want) no longer terminate.